### PR TITLE
Add OpenAI WebSocket chat support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy this file to .env and replace with your actual OpenAI API key
+OPENAI_API_KEY=sk-your-key

--- a/README.md
+++ b/README.md
@@ -1,12 +1,19 @@
 # FastAPI Backend
 
-This backend provides a root endpoint and a simple WebSocket chat.
+This backend provides a root endpoint and WebSocket based chat.
 
 ## Installation
 
 ```bash
 pip install -r requirements.txt
 ```
+
+Create a `.env` file by copying `.env.example` and replacing the OpenAI key:
+
+```bash
+cp .env.example .env
+```
+Edit `.env` and set `OPENAI_API_KEY` with your API key.
 
 ## Running the server
 
@@ -16,11 +23,10 @@ uvicorn main:app --reload
 
 ## WebSocket Chat
 
-Connect to `/ws/chat` with a WebSocket client. Messages are broadcast to all connected clients. 
+Connect to `/chat` with a WebSocket client. Text you send will be forwarded to the OpenAI API and the response will be returned.
 Example using `websocat`:
 
 ```bash
-websocat ws://localhost:8000/ws/chat
+websocat ws://localhost:8000/chat
 ```
 
-Open several terminals with `websocat` to see messages from others.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
 fastapi==0.111.0
 uvicorn==0.29.0
+
+openai==1.14.1
+langchain==0.1.7
+python-dotenv==1.0.1


### PR DESCRIPTION
## Summary
- add OpenAI, LangChain and dotenv dependencies
- provide example `.env` for OpenAI API key
- document env setup and websocket usage in README
- load env variables and implement `/chat` WebSocket route using ChatOpenAI

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_686e589b6d588324853020ec496a9090